### PR TITLE
Fix some errors in the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,4 @@
-# Contributing
-
-Since the project is in an early stage, the contributing guide will develop over time. For the time being you can use
-the following sections for some orientation.
-
-## How to contribute?
+# How to contribute?
 
 Any kind of contribution is welcome as a pull request. If you are unsure on how to fork a repository and then create a pull request from your fork, please read this [blog post](https://reflectoring.io/github-fork-and-pull/) for a quick guide.
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,64 @@
-Buildstate master: [![CircleCI](https://circleci.com/gh/adessoAG/BrainySnake.svg?style=svg)](https://circleci.com/gh/adessoAG/BrainySnake)
-
-[JUG Presentation 27.02.2018](https://cdn.rawgit.com/wiki/adessoAG/BrainySnake/presentations/adessoOSS/BrainySnake/index.html)
+[![CircleCI](https://circleci.com/gh/adessoAG/BrainySnake.svg?style=shield)](https://circleci.com/gh/adessoAG/BrainySnake)
 
 # BrainySnake
 ![brainySnakePic](/Dokumentation/brainySnake.png)
 
-BrainySnake is a game based on the all time classic game "Snake". In BrainySnake you don't actively control your snake but instead program its behaviour so it follows certain patterns.
-During a game, multiple autonomous Snakes are loaded simultaneously and start battling for victory! After 1000 moves (number is adjustable in Config), whoever is still alive and has the most points, wins.
+BrainySnake is a game based on the all time classic game "Snake".
+ In BrainySnake you don't actively control your snake but instead program its behaviour so it follows certain patterns.
+During a game, multiple autonomous snakes are loaded simultaneously and start battling for victory!
+ After 1000 moves (number is adjustable in config), whoever is still alive and has the most points, wins.
 
-# Open Project
+# IDE configuration
 
-## Build Project for IntelliJ
-1. checkout project
-1. run **_gradlew idea_** or for reinit **_gradlew cleanidea idea_** in your favorite console
-(On Unix **./gradlew cleanidea idea**)
-1. open the generated **.ipr** file or **gradlew desktop:run** (On Unix **./gradlew run**)
+## Build Project with IntelliJ
+1. Checkout project
+1. Run `gradlew idea` or for reinit `gradlew cleanidea idea` in your favorite console
+(On Unix `./gradlew cleanidea idea`)
+1. Open the generated `.ipr` with IntelliJ file or `gradlew desktop:run` (On Unix `./gradlew run`)
 
-## Create Desktop Run-Configuration in IntelliJ
-1. create a new Application Configuration
-1. set _de.adesso.brainysnake.desktop.DesktopLauncher_ as Main class
-1. set _[projectPath]\BrainySnake\core\assets_ as Working directory
-1. set _desktop_ as classpath of module
-1. run
+## Create Run Configuration in IntelliJ
+1. Create a new Run Configuration of type _Application_
+1. Set `de.adesso.brainysnake.desktop.DesktopLauncher` as main class
+1. Set `[projectPath]\BrainySnake\core\assets` as working directory
+1. Set `brainysnake.desktop.main` as classpath of module
+1. Run
 
-## Build Project for eclipse
-1. checkout project
-1. import the Project with _File>Import>Gradle>Existing Gradle Project_
+## Build Project for Eclipse
+1. Checkout project
+1. Import the Project with _File>Import>Gradle>Existing Gradle Project_
 
-## Create Desktop Run-Configuration in eclipse
-1. create a Run Configuration and choose _Java Application_
-1. Set _brainySnake-desktop_ as projecct
-1. Set _de.adesso.brainysnake.desktop.DesktopLauncher_ as Main class
+## Create Run Configuration in Eclipse
+1. Create a Run Configuration and choose _Java Application_
+1. Set `brainySnake-desktop` as project
+1. Set `de.adesso.brainysnake.desktop.DesktopLauncher` as main class
 1. Save the new configuration
-1. run
+1. Run
 
-## Rules of the gameController
+# Rules of the game
 
 ![explainSnakePic](/Dokumentation/explainSnake.png)
 
-* Each round in game the Snake can decide to go either right, left, up, down.
-* A Snake consists of a body and a head.
-* If a Snake collides with a level element - an obstacle or a level border - it loses one "part" of its body. If a snake loses all its body parts (i.e. if only the head remains) it dies.
-* If a Snake collects a point a "new part" wie be added to its body (i.e. it gets one field longer). A point is collected by navigating the Snake's head over it.
-* A Snake can bite another snake. In this case the Snake gains a point and enters the "Ghostmode"
-    * During Ghostmode a Snake is protected from other Snakes' bites.
-    * During Ghostmode a Snake can not collect any points or bite other players.
-    * The Ghostmode takes 15 remains (depends on Config)
-* A Snake has a specific field of view. The field of view is a two dimensional grid which can contain the following information:
+* Each round of the game the snake can decide to go either right, left, up or down.
+* A snake consists of a body and a head.
+* If a snake collides with a level element - an obstacle or a level border - it loses one "part" of its body. If a snake loses all its body parts (i.e. if only the head remains), it dies.
+* If a snake collects a point, a "new part" will be added to its body (i.e. it gets one unit longer). A point is collected by navigating the snake's head over it.
+* A snake can bite another snake. In this case the snake gains a point and enters the "Ghostmode"
+    * During Ghostmode a snake is protected from other snake' bites.
+    * During Ghostmode a snake can not collect any points or bite other players.
+    * The Ghostmode lasts for 10 seconds (depends on config)
+* A snake has a specific field of view. The field of view is a two dimensional grid which can contain the following information:
     * Position of level elements (borders, obstacles)
     * Points
-    * Other Snakes
-* If a Snake receives an invalid command (e.g. going directly upwards while moving downwards) it switches into the "ConfusedMode". When entering ConfusedMode the Snake loses one point and starts blinking and will not move.
+    * Other snakes
+* If a snake receives an invalid command (e.g. going directly upwards while moving downwards) it switches into the "ConfusedMode". When entering ConfusedMode, the snake loses one point, starts blinking and will not move.
 
 
-## How To
+# How to create your own AI?
 
-Implement your Snake behaviour in the "YourPlayer" class. You can see the "SamplePlayer" class to get an idea about how to start.
-Give your class a unique name - see the "getPlayerName" method to change your Snake's name. To get used to the movements of the Snakes you can use the arrow keys on your keyboard to control a special Snake which is generated 
-when the Game is loaded.
+Implement your snake behavior in the `YourPlayer` class.
+You can see the `SamplePlayer` class to get an idea about how to start.
+Give your class a unique name - see the `getPlayerName` method to change your snake's name.
+To get used to the movements of the snakes you can use the arrow keys on your keyboard to control a special snake which is generated  when the game is loaded.
 
 ## Want to contribute?
 See the [contribution guide](https://github.com/adessoAG/BrainySnake/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
I have fixed some typos and other errors in the readme and contributing files. These are some more things, I noticed:

- I have removed the link to the presentation at the very top of the readme because it was dead. Is there any way to get the presentation back and create a new link in the readme?
- As you can see, I have altered the instructions for the IntelliJ setup a little bit. For me, using `desktop`as the classpath module did not work. Please check, if my version works for you, too.
- I did not test the setup for Eclipse, maybe you should check its correctness, too.
- I don't understand the following sentence: "The Ghostmode takes 15 remains (depends on Config)". I have not found any `15` in the `Config` class, so I replaced it with some more meaningful sentence.

I hope I could improve the quality of the readme a little bit and am excited to hear from you.